### PR TITLE
feat: weighted load-balancing via `package.json` config

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,8 +108,8 @@ This adds two additional CLI options in addition to those above:
 
 - `--loadBalance`: Toggles load-balancing mode. Defaults to
   `false`.
-- `--packageTestWeightKey myProjectWeight`: The lookup key used to read the project's
-  weight from its package.json. Defaults to `lernaPackageTestWeight`.
+- `--packageWeightKey myProjectWeight`: The lookup key used to read the project's
+  weight from its `package.json`. Defaults to `lernaPackageWeight`.
 
 ### Usage
 
@@ -119,7 +119,7 @@ And add a `lernaPackageTestWeight` property (numeric) to your package.json for e
 If it is missing, `1` is the default weight assigned.
 
 If you have a need to partition differently for multiple CI tasks, you can use
-`--packageTestWeightKey` to specify which weight property should be read from package.json.
+`--packageWeightKey` to specify which weight property should be read from `package.json`.
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ volta install lerna-parallelism
 lerna-parallelism ...
 ```
 
-## Usage
+## Basic Usage
 
 `lerna-parallelism` adds two additional CLI options on top of `lerna`:
 
@@ -92,6 +92,34 @@ others, it does, specifically:
 
 If you'd like to see support for these commands as well, feel free to submit a
 pull request!
+
+## Load Balancing (advanced)
+
+By default, `lerna-parallelism` gives each partition an approximately equal number
+of packages by chunking an alphabetized array. Depending on the number of tests 
+each of your packages has, you may find this results in imbalanced runtimes between 
+partitions.
+
+To address this, `lerna-parallelism` offers a load balancing mode which uses a
+weighted round-robin algorithm, informed by a weight "hint" specified in each 
+package's `package.json`.
+
+This adds two additional CLI options in addition to those above:
+
+- `--loadBalance`: Toggles load-balancing mode. Defaults to
+  `false`.
+- `--packageTestWeightKey myProjectWeight`: The lookup key used to read the project's
+  weight from its package.json. Defaults to `lernaPackageTestWeight`.
+
+### Usage
+
+`lerna-parallelism --loadBalance run test`
+
+And add a `lernaPackageTestWeight` property (numeric) to your package.json for each package.
+If it is missing, `1` is the default weight assigned.
+
+If you have a need to partition differently for multiple CI tasks, you can use
+`--packageTestWeightKey` to specify which weight property should be read from package.json.
 
 ## License
 

--- a/commands/run.js
+++ b/commands/run.js
@@ -15,7 +15,7 @@ class RunCommand extends LernaRunCommand {
         split,
         partition,
         loadBalance,
-        packageTestWeightKey
+        packageWeightKey
       } = this.options;
 
       const { packages, logMessage } = loadBalance
@@ -23,7 +23,7 @@ class RunCommand extends LernaRunCommand {
             this.packagesWithScript,
             split,
             partition,
-            packageTestWeightKey,
+            packageWeightKey,
             this.logger
           )
         : getSplitPackages(this.packagesWithScript, split, partition);

--- a/commands/run.js
+++ b/commands/run.js
@@ -1,19 +1,32 @@
 const { RunCommand: LernaRunCommand } = require('@lerna/run');
 
-const { splittable, getSplitPackages } = require('../options/split');
+const {
+  splittable,
+  getSplitPackages,
+  getLoadBalancedPackages
+} = require('../options/split');
 
 module.exports = { ...require('@lerna/run/command') };
 
 class RunCommand extends LernaRunCommand {
   execute() {
     if (this.options.split > 1) {
-      const { split, partition } = this.options;
-
-      const { packages, logMessage } = getSplitPackages(
-        this.packagesWithScript,
+      const {
         split,
-        partition
-      );
+        partition,
+        loadBalance,
+        packageTestWeightKey
+      } = this.options;
+
+      const { packages, logMessage } = loadBalance
+        ? getLoadBalancedPackages(
+            this.packagesWithScript,
+            split,
+            partition,
+            packageTestWeightKey,
+            this.logger
+          )
+        : getSplitPackages(this.packagesWithScript, split, partition);
 
       this.packagesWithScript = packages;
       this.count = packages.length;

--- a/options/split.js
+++ b/options/split.js
@@ -108,16 +108,12 @@ module.exports.getLoadBalancedPackages = function (
   }
 
   // Init partition weight totals
-  const partitionWeights = {};
-  partitions.forEach((_, index) => {
-    partitionWeights[index] = 0;
-  });
+  const partitionWeights = Array.from({ length: partitions.length }).fill(0);
 
   // Sort packages by weight in descending order.
   // We will put the largest remaining weighted package in the partition with the least total weight.
   const packagesSortedByWeightDesc = [...packages].sort(
-    (a, b) =>
-      (b.get(packageWeightKey) || 1) - (a.get(packageWeightKey) || 1)
+    (a, b) => (b.get(packageWeightKey) || 1) - (a.get(packageWeightKey) || 1)
   );
 
   const getLightestPartition = () => {
@@ -133,7 +129,7 @@ module.exports.getLoadBalancedPackages = function (
     return minId;
   };
 
-  packagesSortedByWeightDesc.forEach(project => {
+  for (const project of packagesSortedByWeightDesc) {
     const lightestPartition = getLightestPartition();
     logger.debug(
       `Adding package ${project.name} (weight: ${project.get(
@@ -141,9 +137,8 @@ module.exports.getLoadBalancedPackages = function (
       )}) to partition ${lightestPartition}`
     );
     partitions[lightestPartition].push(project);
-    partitionWeights[lightestPartition] +=
-      project.get(packageWeightKey) || 1;
-  });
+    partitionWeights[lightestPartition] += project.get(packageWeightKey) || 1;
+  }
 
   logger.debug(
     partitions.map(part =>

--- a/options/split.js
+++ b/options/split.js
@@ -22,12 +22,25 @@ module.exports.splittable = yargs =>
     .option('split', {
       type: 'number',
       default: CIRCLE_NODE_TOTAL ? Number.parseInt(CIRCLE_NODE_TOTAL, 10) : 1,
-      defaultDescription: '$CIRCLE_NODE_TOTAL ?? 1'
+      defaultDescription: 'The number of partitions.  $CIRCLE_NODE_TOTAL ?? 1'
     })
     .option('partition', {
       type: 'number',
       default: CIRCLE_NODE_INDEX ? Number.parseInt(CIRCLE_NODE_INDEX, 10) : 0,
-      defaultDescription: '$CIRCLE_NODE_INDEX ?? 0'
+      defaultDescription:
+        'The partition ID for this instance to execute.  $CIRCLE_NODE_INDEX ?? 0'
+    })
+    .option('loadBalance', {
+      type: 'boolean',
+      default: false,
+      defaultDescription:
+        'Use a greedy round-robin load balancing algo instead of default split'
+    })
+    .option('packageTestWeightKey', {
+      type: 'string',
+      default: 'lernaPackageTestWeight',
+      defaultDescription:
+        "The lookup key to use for reading the project's weight from its package.json"
     })
     .check(({ split, partition }) => {
       validate(split, partition);
@@ -69,6 +82,82 @@ module.exports.getSplitPackages = function (packages, split, partition) {
 
   return {
     logMessage: `Split ${
+      partition + 1
+    }/${split} (${partitionSize} packages of ${total} packages total)`,
+    partitionSize,
+    total,
+    packages: chunk
+  };
+};
+
+module.exports.getLoadBalancedPackages = function (
+  packages,
+  split,
+  partition,
+  packageTestWeightKey,
+  logger
+) {
+  validate(split, partition);
+
+  const total = packages.length;
+
+  // Init empty partitions
+  const partitions = [];
+  for (let i = 0; i < split; i++) {
+    partitions.push([]);
+  }
+
+  // Init partition weight totals
+  const partitionWeights = {};
+  partitions.forEach((_, index) => {
+    partitionWeights[index] = 0;
+  });
+
+  // Sort packages by weight in descending order.
+  // We will put the largest remaining weighted package in the partition with the least total weight.
+  const packagesSortedByWeightDesc = [...packages].sort(
+    (a, b) =>
+      (b.get(packageTestWeightKey) || 1) - (a.get(packageTestWeightKey) || 1)
+  );
+
+  const getLightestPartition = () => {
+    let minId;
+    let minWeight = Number.MAX_SAFE_INTEGER;
+    for (let i = 0; i < split; i++) {
+      if (minWeight > partitionWeights[i]) {
+        minWeight = partitionWeights[i];
+        minId = i;
+      }
+    }
+
+    return minId;
+  };
+
+  packagesSortedByWeightDesc.forEach(project => {
+    const lightestPartition = getLightestPartition();
+    logger.debug(
+      `Adding package ${project.name} (weight: ${project.get(
+        packageTestWeightKey
+      )}) to partition ${lightestPartition}`
+    );
+    partitions[lightestPartition].push(project);
+    partitionWeights[lightestPartition] +=
+      project.get(packageTestWeightKey) || 1;
+  });
+
+  logger.debug(
+    partitions.map(part =>
+      part.map(pack => [pack.name, pack.get(packageTestWeightKey) || 1])
+    )
+  );
+  logger.debug(partitionWeights);
+
+  const chunk = partitions[partition];
+
+  const partitionSize = chunk.length;
+
+  return {
+    logMessage: `Load Balanced Split ${
       partition + 1
     }/${split} (${partitionSize} packages of ${total} packages total)`,
     partitionSize,

--- a/options/split.js
+++ b/options/split.js
@@ -36,9 +36,9 @@ module.exports.splittable = yargs =>
       defaultDescription:
         'Use a greedy round-robin load balancing algo instead of default split'
     })
-    .option('packageTestWeightKey', {
+    .option('packageWeightKey', {
       type: 'string',
-      default: 'lernaPackageTestWeight',
+      default: 'lernaPackageWeight',
       defaultDescription:
         "The lookup key to use for reading the project's weight from its package.json"
     })
@@ -94,7 +94,7 @@ module.exports.getLoadBalancedPackages = function (
   packages,
   split,
   partition,
-  packageTestWeightKey,
+  packageWeightKey,
   logger
 ) {
   validate(split, partition);
@@ -117,7 +117,7 @@ module.exports.getLoadBalancedPackages = function (
   // We will put the largest remaining weighted package in the partition with the least total weight.
   const packagesSortedByWeightDesc = [...packages].sort(
     (a, b) =>
-      (b.get(packageTestWeightKey) || 1) - (a.get(packageTestWeightKey) || 1)
+      (b.get(packageWeightKey) || 1) - (a.get(packageWeightKey) || 1)
   );
 
   const getLightestPartition = () => {
@@ -137,17 +137,17 @@ module.exports.getLoadBalancedPackages = function (
     const lightestPartition = getLightestPartition();
     logger.debug(
       `Adding package ${project.name} (weight: ${project.get(
-        packageTestWeightKey
+        packageWeightKey
       )}) to partition ${lightestPartition}`
     );
     partitions[lightestPartition].push(project);
     partitionWeights[lightestPartition] +=
-      project.get(packageTestWeightKey) || 1;
+      project.get(packageWeightKey) || 1;
   });
 
   logger.debug(
     partitions.map(part =>
-      part.map(pack => [pack.name, pack.get(packageTestWeightKey) || 1])
+      part.map(pack => [pack.name, pack.get(packageWeightKey) || 1])
     )
   );
   logger.debug(partitionWeights);

--- a/options/split.test.js
+++ b/options/split.test.js
@@ -1,4 +1,4 @@
-const { getChunkBounds } = require('./split');
+const { getChunkBounds, getLoadBalancedPackages } = require('./split');
 
 describe('getChunkBounds', () => {
   for (let totalSize = 0; totalSize <= 20; totalSize++) {
@@ -22,4 +22,95 @@ describe('getChunkBounds', () => {
       });
     }
   }
+});
+
+class MockPackage {
+  constructor(name, weight) {
+    this.name = name;
+    this.weight = weight;
+  }
+
+  get() {
+    return this.weight;
+  }
+}
+
+const mockLogger = { debug: () => {}, info: () => {} };
+
+describe('getLoadBalancedPackages', () => {
+  it('handles extreme case of one super heavy package', () => {
+    const sourcePackages = [
+      new MockPackage('a', 2),
+      new MockPackage('b', 3),
+      new MockPackage('c', 5),
+      new MockPackage('d', 400),
+      new MockPackage('e', 2)
+    ];
+
+    const { packages } = getLoadBalancedPackages(
+      sourcePackages,
+      2,
+      0,
+      'mocked',
+      mockLogger
+    );
+
+    expect(packages.length).toBe(1);
+    expect(packages[0].weight).toBe(400);
+
+    const { packages: secondPartition } = getLoadBalancedPackages(
+      sourcePackages,
+      2,
+      1,
+      'mocked',
+      mockLogger
+    );
+
+    expect(secondPartition.length).toBe(4);
+  });
+
+  it('handles a moderate case', () => {
+    const sourcePackages = [
+      new MockPackage('a', 10),
+      new MockPackage('b', 5),
+      new MockPackage('c', 5),
+      new MockPackage('d', 5),
+      new MockPackage('e', 2),
+      new MockPackage('f', 2),
+      new MockPackage('g', 2),
+      new MockPackage('h', 1),
+      new MockPackage('i', 1)
+    ];
+
+    // for 3 partitions, expecting this to end up as
+    // 1: a(10) - h(1)
+    // 2: b(5)  - d(5) - i(1)
+    // 3: c(5)  - e(2) - f(2) - g(2)
+
+    const { packages: firstPartition } = getLoadBalancedPackages(
+      sourcePackages,
+      3,
+      0,
+      'mocked',
+      mockLogger
+    );
+    const { packages: secondPartition } = getLoadBalancedPackages(
+      sourcePackages,
+      3,
+      1,
+      'mocked',
+      mockLogger
+    );
+    const { packages: thirdPartition } = getLoadBalancedPackages(
+      sourcePackages,
+      3,
+      2,
+      'mocked',
+      mockLogger
+    );
+
+    expect(firstPartition.length).toBe(2);
+    expect(secondPartition.length).toBe(3);
+    expect(thirdPartition.length).toBe(4);
+  });
 });


### PR DESCRIPTION
### Add load-balance feature to partition by hinted weight for more equal runtimes

This PR closes #13 by adding a greedy round-robin weighted load balancing algorithm.  Each package can declare a numeric weight in `package.json`, and with a `--load-balance` CLI argument, the packages will be grouped in partitions with approximately equal runtimes.

Tests are added as well as README usage notes.

Use of the `--packageTestWeightKey ` is likely rare, but for advanced use cases with multiple CI processes (say, typechecking, tests, and linting) it is possible that different partitioning strategies may be desired for each of these.