### PR TITLE
refactor: `--distribute-by count|weight`

### DIFF
--- a/README.md
+++ b/README.md
@@ -125,11 +125,13 @@ The following commands from `lerna` are supported:
 
 [lerna-run]: https://github.com/lerna/lerna/blob/master/commands/run#readme
 
+> Run an npm script in each package that contains that script.
+
 For instance, this executes the last of four partitions. It also passes along
 `--stream` & `--concurrency 1` to prefix log lines with the package name.
 
 ```sh
-yarn lerna run \
+lerna-parallelism run \
   --stream \
   --concurrency 1 \
   --split 4 \

--- a/README.md
+++ b/README.md
@@ -24,6 +24,12 @@ multiple workers, like [CircleCI's `parallelism` feature][circleci-parallelism].
 [lerna]: https://github.com/lerna/lerna
 [circleci-parallelism]: https://circleci.com/docs/2.0/parallelism-faster-jobs/
 
+- [Introduction](#Introduction)
+  - [Use Case](#Use-Case)
+  - [Quick Example](#Quick-Example)
+- [Installation](#Installation)
+- [Usage](#Usage)
+
 ## Introduction
 
 ### Use Case

--- a/commands/run.js
+++ b/commands/run.js
@@ -36,9 +36,10 @@ class RunCommand extends LernaRunCommand {
 
 module.exports.RunCommand = this.RunCommand;
 
-module.exports.handler = function handler(argv) {
-  return new RunCommand(argv);
-};
+/** @param {import('@types/yargs').Argv} argv */
+module.exports.handler = argv => new RunCommand(argv);
 
 const { builder } = module.exports;
+
+/** @param {import('@types/yargs').Argv} yargs */
 module.exports.builder = yargs => splittable(builder(yargs));

--- a/commands/run.js
+++ b/commands/run.js
@@ -12,17 +12,23 @@ module.exports = { ...requireFromLerna('@lerna/run/command') };
 class RunCommand extends LernaRunCommand {
   execute() {
     if (this.options.split > 1) {
-      const { split, partition, loadBalance, packageWeightKey } = this.options;
+      const { split, partition, distributeBy, packageWeightKey } = this.options;
 
-      const { packages, logMessage } = loadBalance
-        ? getLoadBalancedPackages(
-            this.packagesWithScript,
-            split,
-            partition,
-            packageWeightKey,
-            this.logger
-          )
-        : getSplitPackages(this.packagesWithScript, split, partition);
+      const { packages, logMessage } = (() => {
+        switch (distributeBy) {
+          case 'weight':
+            return getLoadBalancedPackages(
+              this.packagesWithScript,
+              split,
+              partition,
+              packageWeightKey,
+              this.logger
+            );
+          default:
+          case 'count':
+            return getSplitPackages(this.packagesWithScript, split, partition);
+        }
+      })();
 
       this.packagesWithScript = packages;
       this.count = packages.length;

--- a/index.js
+++ b/index.js
@@ -5,7 +5,8 @@ const { requireFromLerna } = require('./utils/require-from');
 
 const lernaCLI = requireFromLerna('@lerna/cli');
 
-module.exports.main = function main(argv) {
+/** @param {import('@types/yargs').Argv} argv */
+module.exports.main = function (argv) {
   const context = {
     lernaVersion: lernaPkg.version
   };

--- a/options/split.js
+++ b/options/split.js
@@ -29,27 +29,33 @@ function validate(split, partition) {
 module.exports.splittable = yargs =>
   yargs
     .option('split', {
+      group: 'Partition Count',
       type: 'number',
       default: CIRCLE_NODE_TOTAL ? Number.parseInt(CIRCLE_NODE_TOTAL, 10) : 1,
       defaultDescription: 'The number of partitions.  $CIRCLE_NODE_TOTAL ?? 1'
     })
     .option('partition', {
+      group: 'Partition Count',
       type: 'number',
       default: CIRCLE_NODE_INDEX ? Number.parseInt(CIRCLE_NODE_INDEX, 10) : 0,
       defaultDescription:
         'The partition ID for this instance to execute.  $CIRCLE_NODE_INDEX ?? 0'
     })
-    .option('loadBalance', {
-      type: 'boolean',
-      default: false,
-      defaultDescription:
-        'Use a greedy round-robin load balancing algo instead of default split'
+    .option('distributeBy', {
+      group: 'Distribution Strategy',
+      description:
+        'Algorithm to use for deciding which package goes into which partition.',
+      type: 'string',
+      choices: ['count', 'weight'],
+      default: 'count',
+      defaultDescription: 'Split into even-sized partitions.'
     })
     .option('packageWeightKey', {
+      group: 'Distribution Strategy',
+      description:
+        "The lookup key to use for reading the package's weight from its `package.json`",
       type: 'string',
-      default: 'lernaPackageWeight',
-      defaultDescription:
-        "The lookup key to use for reading the project's weight from its package.json"
+      default: 'lernaPackageWeight'
     })
     .check(({ split, partition }) => {
       validate(split, partition);

--- a/options/split.js
+++ b/options/split.js
@@ -2,6 +2,12 @@ const assert = require('assert');
 
 const { CIRCLE_NODE_INDEX, CIRCLE_NODE_TOTAL } = process.env;
 
+/**
+ * Asserts that the `split` and `partition` values are valid.
+ *
+ * @param {number} split The total number of chunks.
+ * @param {number} partition The zero-based index of a chunk.
+ */
 function validate(split, partition) {
   assert(
     Number.isSafeInteger(split) && split > 0,
@@ -17,6 +23,9 @@ function validate(split, partition) {
   );
 }
 
+/**
+ * @param {import('@types/yargs').Argv} yargs
+ */
 module.exports.splittable = yargs =>
   yargs
     .option('split', {
@@ -52,7 +61,12 @@ module.exports.splittable = yargs =>
  * `array.slice(start, end)`, where `end` is non-inclusive, to slice an array of
  * `totalSize` into `chunkCount` balanced chunks.
  *
- * @return [start, end]
+ * @param {number} totalSize The total size of the array to be sliced.
+ * @param {number} chunkCount The number of chunks to slice the array into.
+ * @param {number} chunkIndex The zero-based index of the chunk to return the
+ * `[start, end]` bounds for.
+ *
+ * @returns {[start: number, end: number]}
  */
 function getChunkBounds(totalSize, chunkCount, chunkIndex) {
   validate(chunkCount, chunkIndex);
@@ -71,6 +85,16 @@ function getChunkBounds(totalSize, chunkCount, chunkIndex) {
 
 module.exports.getChunkBounds = getChunkBounds;
 
+/**
+ * Split `packages` into `split`evenly-sized chunks, returning the `partition`
+ * chunk.
+ *
+ * @param {Package[]} packages The list of packages to be distributed.
+ * @param {number} split The number of chunks to distribute the packages into.
+ * @param {number} partition The zero-based index of the chunk to return.
+ *
+ * @returns The chunk identified by `partition`.
+ */
 module.exports.getSplitPackages = function (packages, split, partition) {
   validate(split, partition);
 
@@ -90,6 +114,20 @@ module.exports.getSplitPackages = function (packages, split, partition) {
   };
 };
 
+/**
+ * Split `packages` into `split` evenly-weighted chunks, using
+ * `packageWeightKey` to lookup the weight of each package from its
+ * `package.json`.
+ *
+ * @param {Package[]} packages The list of packages to be distributed.
+ * @param {number} split The number of chunks to distribute the packages into.
+ * @param {number} partition The zero-based index of the chunk to return.
+ * @param {string} packageWeightKey The lookup key to use for reading the
+ * packages's estimated weight from its `package.json`.
+ * @param {Logger} logger
+ *
+ * @returns The chunk identified by `partition`.
+ */
 module.exports.getLoadBalancedPackages = function (
   packages,
   split,


### PR DESCRIPTION
- Refactor the CLI for the weighted distribution feature introduced by #14.
  Distribution strategy is selected via `--distribute-by count|weight` and defaults to `count`.
- Improve `README.md`.
- Add `DocBlock` comments.